### PR TITLE
[PLAT-432] need this order for AWS, sigh

### DIFF
--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -31,6 +31,9 @@ spec:
       - name: metrics-server
         image: k8s.gcr.io/metrics-server-amd64:v0.3.1
         imagePullPolicy: Always
+        command: 
+          - /metrics-server 
+          - --kubelet-preferred-address-types InternalIP,InternalDNS,Hostname.ExternalDNS,ExternalIP
         volumeMounts:
         - name: tmp-dir
           mountPath: /tmp


### PR DESCRIPTION
I can post the litany of github issues that led to this, but basically we need this change to the metrics-server if we want `kubectl top nodes` to work on AWS EC2, which I think we do.

The helm chart for metrics server is not maintained by the real metrics-server maintainers, so anyway this seems a better way to uptake this stuff.

(It used to be heapster etc, but that's deprecated and stuff).

(This also enables some DD metrics collecting stuff)